### PR TITLE
chore(deps): Updating nix/treelib/default.nix

### DIFF
--- a/nix/treelib/default.nix
+++ b/nix/treelib/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "treelib";
-  version = "1.6.1";
+  version = "1.6.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-HL//stK3XMrCfQIAzuBQe2+7Bybgr7n64Bet5dLOh4g=";
+    sha256 = "sha256-Gi6Dj2uZ4mkLw9mS1aHwTNtK9lZL12iIg8I9FyV7uyo=";
   };
 
   propagatedBuildInputs = [ future ];


### PR DESCRIPTION
    ### Changes for nix/treelib/default.nix

    ```diff
    --- 
+++ 
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "treelib";
-  version = "1.6.1";
+  version = "1.6.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-HL//stK3XMrCfQIAzuBQe2+7Bybgr7n64Bet5dLOh4g=";
+    sha256 = "sha256-Gi6Dj2uZ4mkLw9mS1aHwTNtK9lZL12iIg8I9FyV7uyo=";
   };
 
   propagatedBuildInputs = [ future ];

    ```
    